### PR TITLE
Added test for "--show-mbps".

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,4 @@ jobs:
         python nordvpn_best.py --debug 'Sydney, AU'
         python nordvpn_best.py --debug 'US' --load 15
         python nordvpn_best.py --debug 'AU' --load 10 --fping
+        python nordvpn_best.py --debug 'Sydney, AU' --show-mbps


### PR DESCRIPTION
I believe something is broken in the script now with `show-mbps` option because I'm getting
```
IndexError: list index out of range
```

After a quick investigation it looks like NordVPN server does not return bandwidth in it's json anymore in the `specifications` field.